### PR TITLE
Fixing some errors BMGEditing.py

### DIFF
--- a/src/bmgedit/BMGEditing.py
+++ b/src/bmgedit/BMGEditing.py
@@ -23,7 +23,7 @@ __author__ = 'David Schaller'
 class BMGEditor:
     """Wrapper for triple-based BMG editing heuristics."""
     
-    def __init__(self, G, binary=False, binarization_mode='balanced',use_binary_triples=True):
+    def __init__(self, G, binary=False, binarization_mode='balanced', use_binary_triples=True):
         
         self.G = G
         self.color_dict = sort_by_colors(G)
@@ -43,8 +43,8 @@ class BMGEditor:
             
         # current tree built by one of the heuristics
         self._tree = None
-        
-    
+
+
     def extract_consistent_triples(self):
         
         if not self._tree:
@@ -66,7 +66,7 @@ class BMGEditor:
         else:
             raise ValueError('unknown mode for objective ' \
                              'function: {}'.format(objective))
-        
+
         method = method.lower()
         
         if method == 'bpmf':
@@ -82,7 +82,7 @@ class BMGEditor:
                            minimize=minimize,
                            obj_function_args=(self.G,),
                            weighted_mincut=True,
-                           binary_triples=self.binary_triples)
+                          )
             self._tree = build.build_tree()
         else:
             raise ValueError('unknown partition method: {}'.format(method))
@@ -99,7 +99,7 @@ class BMGEditor:
             build = Build2(R_consistent, self.L,
                            allow_inconsistency=False,
                            binarize=self.binarize,
-                           binary_triples=self.binary_triples)
+                          )
             tree = build.build_tree()
             reconstruct_reconc_from_graph(tree, self.G)
         


### PR DESCRIPTION
# Testing BMGEdit

Testing the BMGedit method, when I try to use it, I obtain the error

```python
File "/home/jarr/Documents/Taller/revolutionhtl/hug_free.py", line 31, in build_graph
    solver.build(method, objective)
  File "/home/jarr/Documents/Taller/bmgedit/BMGEditing.py", line 85, in build
    binary_triples=self.binary_triples)
                   ^^^^^^^^^^^^^^^^^^^
AttributeError: 'BMGEditor' object has no attribute 'binary_triples'
```

**The error:** When using the class `Build2` in the lines 77 and 100 of the file `BMGEditing.py`:

It is specified the keyword argument `binary_triples=self.binary_triples`. This is wrong because the object `self.binary_triples` doesn't exists.

The correct attribute where the triples are stored is `self.R`, this is specified in the method `__init__` of the class `BMGEditor`, in the lines 34-42.

**Another error:** Let's look to again at lines 77 and 100 of the file `BMGEditing.py`:

After the correction of the previous error, we use the following keyword argument `binary_triples=self.R` when calling the class `Build2`.

This is still wrong: looking at the method `__init__` of the class `Build2` in the file `Build.py`:

```python
class Build2:
    """BUILD / MTT algorithm with optimal objective partition."""
    
    def __init__(self, R, L, F=None,
                 allow_inconsistency=True,
                 binarize=False,
                 part_method='mincut',
                 obj_function=None,
                 minimize=True,
                 obj_function_args=None,
                 greedy_repeats=5,
                 weighted_mincut=False, triple_weights=None):

[...]
```

Note that there is NOT a keyword argument ` binary_triples`, then the lines 77 and 100 of the file `BMGEditing.py` are wrong.

On the other hand, in the method `__init__` of the class `Build2` in the file `Build.py`, there is an attribute `R` which is designed to hold the triples (no matter if they are classic informative triples, or if they are binary triples).

If you look back in the file `BMGEditing.py`, when using the class `Build2`, the triples are specified in the first argument (lines 77 and 100).